### PR TITLE
Fix warning

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,12 @@ See http://github.com/miyagawa/cpanminus/ for the latest development.
 
 {{$NEXT}}
 
+1.7039.5  2018-12-11 12:56:36 EDT
+    MF: fix logging for metacpan queries
+
+1.7039.4  2018-11-15 11:39:10 EDT
+    MF: fastapi support
+
 1.7039.3  2016-02-16 13:27:00 EDT
     PK: Allow passing in of params to Makefile.PL via ENV
 

--- a/META.json
+++ b/META.json
@@ -101,7 +101,7 @@
          "web" : "https://github.com/miyagawa/cpanminus"
       }
    },
-   "version" : "1.7039.4",
+   "version" : "1.7039.5",
    "x_contributors" : [
       "Alessandro Ghedini <al3xbio@gmail.com>",
       "Andrew Rodland <andrew@cleverdomain.org>",

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -38,7 +38,7 @@ my %WriteMakefileArgs = (
   "TEST_REQUIRES" => {
     "Test::More" => 0
   },
-  "VERSION" => "1.7039.4",
+  "VERSION" => "1.7039.5",
   "test" => {
     "TESTS" => "t/*.t"
   }

--- a/cpanm
+++ b/cpanm
@@ -21,7 +21,7 @@ BEGIN {
 my %fatpacked;
 
 $fatpacked{"App/cpanminus.pm"} = '#line '.(1+__LINE__).' "'.__FILE__."\"\n".<<'APP_CPANMINUS';
-  package App::cpanminus;our$VERSION="1.7039.4";1;
+  package App::cpanminus;our$VERSION="1.7039.5";1;
 APP_CPANMINUS
 
 $fatpacked{"App/cpanminus/Dependency.pm"} = '#line '.(1+__LINE__).' "'.__FILE__."\"\n".<<'APP_CPANMINUS_DEPENDENCY';

--- a/lib/App/cpanminus.pm
+++ b/lib/App/cpanminus.pm
@@ -1,5 +1,5 @@
 package App::cpanminus;
-our $VERSION = "1.7039.4";
+our $VERSION = "1.7039.5";
 
 =encoding utf8
 

--- a/lib/App/cpanminus/script.pm
+++ b/lib/App/cpanminus/script.pm
@@ -752,7 +752,7 @@ sub search_metacpan {
                 if length $query;
 
             my $dist_json = $self->get($url);
-            my $dist_meta = eval { $self->decode_json($dist_json) } or warn "$@";
+            my $dist_meta = eval { $self->decode_json($dist_json) };
 
             if ($dist_meta && $dist_meta->{download_url}) {
                 (my $distfile = $dist_meta->{download_url}) =~ s!.+/authors/id/!!;
@@ -760,6 +760,8 @@ sub search_metacpan {
                 $self->{mirrors} = [ 'http://cpan.metacpan.org' ];
                 return $self->cpan_module($module, $distfile, $dist_meta->{version});
             }
+
+            $self->chat("! Could not find a release matching $module".($version?" ($version)":'')." via CPAN API ($metacpan_uri).\n");
         }
     }
 


### PR DESCRIPTION
Fixes spurious "malformed JSON string" warnings when querying metacpan.

The upstream code wasn't logging `$@` and I had only added it in for debugging purposes.