### PR TITLE
set PERL_USE_UNSAFE_INC so . is included in @INC

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 See http://github.com/miyagawa/cpanminus/ for the latest development.
 
 {{$NEXT}}
+    MF: set PERL_USE_UNSAFE_INC so . is included in @INC
 
 1.7039.5  2018-12-11 12:56:36 EDT
     MF: fix logging for metacpan queries

--- a/lib/App/cpanminus/script.pm
+++ b/lib/App/cpanminus/script.pm
@@ -1367,6 +1367,9 @@ sub configure {
         $ENV{PERL_MB_OPT} .= " --pureperl-only";
     }
 
+    local $ENV{PERL_USE_UNSAFE_INC} = 1
+        unless exists $ENV{PERL_USE_UNSAFE_INC};
+
     $cmd = $self->append_args($cmd, 'configure') if $depth == 0;
 
     local $self->{verbose} = $self->{verbose} || $self->{interactive};
@@ -1377,6 +1380,9 @@ sub build {
     my($self, $cmd, $distname, $depth) = @_;
 
     local $ENV{PERL_MM_USE_DEFAULT} = !$self->{interactive};
+
+    local $ENV{PERL_USE_UNSAFE_INC} = 1
+        unless exists $ENV{PERL_USE_UNSAFE_INC};
 
     $cmd = $self->append_args($cmd, 'build') if $depth == 0;
 
@@ -1399,6 +1405,9 @@ sub test {
 
     # https://github.com/Perl-Toolchain-Gang/toolchain-site/blob/master/lancaster-consensus.md
     local $ENV{NONINTERACTIVE_TESTING} = !$self->{interactive};
+
+    local $ENV{PERL_USE_UNSAFE_INC} = 1
+        unless exists $ENV{PERL_USE_UNSAFE_INC};
 
     $cmd = $self->append_args($cmd, 'test') if $depth == 0;
 
@@ -1425,6 +1434,9 @@ sub install {
     if ($depth == 0 && $self->{test_only}) {
         return 1;
     }
+
+    local $ENV{PERL_USE_UNSAFE_INC} = 1
+        unless exists $ENV{PERL_USE_UNSAFE_INC};
 
     if ($self->{sudo}) {
         unshift @$cmd, "sudo";


### PR DESCRIPTION
New perl versions will stop including . in @INC by default.  The
PERL_USE_UNSAFE_INC environment variable can be set to re-add it.

A large number of dists rely on . in @INC either for their Makefile.PL
or tests, so set it when running any of the commands.